### PR TITLE
Change do_get definition to private

### DIFF
--- a/lib/fastglobal.ex
+++ b/lib/fastglobal.ex
@@ -44,7 +44,7 @@ defmodule FastGlobal do
   ## Private
 
   @spec do_get(atom, any) :: any
-  def do_get(module, default) do
+  defp do_get(module, default) do
     try do
       module.value
     catch


### PR DESCRIPTION
This PR changes the definition of `do_get` to be private using `defp` like it seems to be meant to.