### PR TITLE
Fix Elixir 1.17 compiler warnings

### DIFF
--- a/lib/fastglobal.ex
+++ b/lib/fastglobal.ex
@@ -46,7 +46,7 @@ defmodule FastGlobal do
   @spec do_get(atom, any) :: any
   defp do_get(module, default) do
     try do
-      module.value
+      module.value()
     catch
       :error, :undef ->
         default
@@ -57,7 +57,7 @@ defmodule FastGlobal do
   defp do_put(module, value) do
     binary = compile(module, value)
     :code.purge(module)
-    {:module, ^module} = :code.load_binary(module, '#{module}.erl', binary)
+    {:module, ^module} = :code.load_binary(module, ~c"#{module}.erl", binary)
     :ok
   end
 


### PR DESCRIPTION
Elixir 1.17 compiler emits warnings for single-quote charlists, requiring `~c` sigils for them instead, and for map.field notation without parentheses. These warnings are fixed in this PR.